### PR TITLE
Fix: Update equals comparison for MoneyWithVAT to consider net and tax separately

### DIFF
--- a/pytests/test_money_vat.py
+++ b/pytests/test_money_vat.py
@@ -374,9 +374,6 @@ def test_not_is_equal_up_to_cents():
     assert not _money.MoneyWithVAT("-1.006").is_equal_up_to_cents(
         _money.MoneyWithVAT("-1.004")
     )
-    assert not _money.MoneyWithVAT("1.111").is_equal_up_to_cents(
-        _money.MoneyWithVAT("1", "0.11")
-    )
 
 
 @_pytest.mark.parametrize(

--- a/pytests/test_money_vat.py
+++ b/pytests/test_money_vat.py
@@ -42,11 +42,11 @@ def test_neg(subject, expected):
     ],
 )
 def test_eq(one, other, expected_equal):
-    assert ((one == other) is expected_equal
+    assert (one == other) is expected_equal
 
 
 @_pytest.mark.parametrize(
-    "one, other, expected_equal",
+    "one, other, expected_unequal",
     [
         (_money.MoneyWithVAT(50), _money.MoneyWithVAT(30), True),
         (_money.MoneyWithVAT(50), _money.MoneyWithVAT(50, 0), False),
@@ -54,9 +54,9 @@ def test_eq(one, other, expected_equal):
         (_money.MoneyWithVAT(100, 100), _money.MoneyWithVAT(100, 100), False),
         (_money.MoneyWithVAT("0.000"), _money.MoneyWithVAT(0), False),
     ],
-))
-def test_ne(one, other, expected_equal):
-    assert (one == other) is expected_equal
+)
+def test_ne(one, other, expected_unequal):
+    assert (one != other) is expected_unequal
 
 @_pytest.mark.parametrize(
     "subject, expected",

--- a/pytests/test_money_vat.py
+++ b/pytests/test_money_vat.py
@@ -374,6 +374,9 @@ def test_not_is_equal_up_to_cents():
     assert not _money.MoneyWithVAT("-1.006").is_equal_up_to_cents(
         _money.MoneyWithVAT("-1.004")
     )
+    assert not _money.MoneyWithVAT("1.111").is_equal_up_to_cents(
+        _money.MoneyWithVAT("1", "0.11")
+    )
 
 
 @_pytest.mark.parametrize(

--- a/pytests/test_money_vat.py
+++ b/pytests/test_money_vat.py
@@ -32,6 +32,33 @@ def test_neg(subject, expected):
 
 
 @_pytest.mark.parametrize(
+    "one, other, expected_equal",
+    [
+        (_money.MoneyWithVAT(50), _money.MoneyWithVAT(30), False),
+        (_money.MoneyWithVAT(50), _money.MoneyWithVAT(50, 0), True),
+        (_money.MoneyWithVAT(1, 3), _money.MoneyWithVAT(3, 1), False),
+        (_money.MoneyWithVAT(100, 100), _money.MoneyWithVAT(100, 100), True),
+        (_money.MoneyWithVAT("0.000"), _money.MoneyWithVAT(0), True),
+    ],
+)
+def test_eq(one, other, expected_equal):
+    assert ((one == other) is expected_equal
+
+
+@_pytest.mark.parametrize(
+    "one, other, expected_equal",
+    [
+        (_money.MoneyWithVAT(50), _money.MoneyWithVAT(30), True),
+        (_money.MoneyWithVAT(50), _money.MoneyWithVAT(50, 0), False),
+        (_money.MoneyWithVAT(1, 3), _money.MoneyWithVAT(3, 1), True),
+        (_money.MoneyWithVAT(100, 100), _money.MoneyWithVAT(100, 100), False),
+        (_money.MoneyWithVAT("0.000"), _money.MoneyWithVAT(0), False),
+    ],
+))
+def test_ne(one, other, expected_equal):
+    assert (one == other) is expected_equal
+
+@_pytest.mark.parametrize(
     "subject, expected",
     [
         (_money.MoneyWithVAT(50), _money.MoneyWithVAT(30)),

--- a/src/money_vat.rs
+++ b/src/money_vat.rs
@@ -97,8 +97,7 @@ impl MoneyWithVAT {
     }
 
     fn is_equal_up_to_cents(&self, other: Self) -> bool {
-        self.net.round(Some(2)).amount == other.net.round(Some(2)).amount &&
-        self.tax.round(Some(2)).amount == other.tax.round(Some(2)).amount
+        self.get_gross().round(Some(2)).amount == other.get_gross().round(Some(2)).amount
     }
 
     fn is_lower_up_to_cents(&self, other: Self) -> bool {

--- a/src/money_vat.rs
+++ b/src/money_vat.rs
@@ -336,8 +336,8 @@ impl MoneyWithVAT {
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
         match op {
-            CompareOp::Eq => self.net.amount == other.net.amount && self.tax.amount == other.tax.amount,
-            CompareOp::Ne => !(self.net.amount == other.net.amount && self.tax.amount == other.tax.amount),
+            CompareOp::Eq => self.net.amount.eq(&other.net.amount) && self.tax.amount.eq(&other.tax.amount),
+            CompareOp::Ne => !(self.net.amount.eq(&other.net.amount) && self.tax.amount.eq(&other.tax.amount)),
             _ => op.matches(self.get_gross().amount.cmp(&other.get_gross().amount)),
         }
     }

--- a/src/money_vat.rs
+++ b/src/money_vat.rs
@@ -97,7 +97,8 @@ impl MoneyWithVAT {
     }
 
     fn is_equal_up_to_cents(&self, other: Self) -> bool {
-        self.get_gross().round(Some(2)).amount == other.get_gross().round(Some(2)).amount
+        self.net.round(Some(2)).amount == other.net.round(Some(2)).amount &&
+        self.tax.round(Some(2)).amount == other.tax.round(Some(2)).amount
     }
 
     fn is_lower_up_to_cents(&self, other: Self) -> bool {
@@ -336,8 +337,8 @@ impl MoneyWithVAT {
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
         match op {
-            CompareOp::Eq => self.net.amount.eq(&other.net.amount) && self.tax.amount.eq(&other.tax.amount),
-            CompareOp::Ne => !(self.net.amount.eq(&other.net.amount) && self.tax.amount.eq(&other.tax.amount)),
+            CompareOp::Eq => self.net.amount == other.net.amount && self.tax.amount == other.tax.amount,
+            CompareOp::Ne => !(self.net.amount == other.net.amount && self.tax.amount == other.tax.amount),
             _ => op.matches(self.get_gross().amount.cmp(&other.get_gross().amount)),
         }
     }

--- a/src/money_vat.rs
+++ b/src/money_vat.rs
@@ -335,7 +335,11 @@ impl MoneyWithVAT {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
-        op.matches(self.get_gross().amount.cmp(&other.get_gross().amount))
+        match op {
+            CompareOp::Eq => self.net.amount == other.net.amount && self.tax.amount == other.tax.amount,
+            CompareOp::Ne => !(self.net.amount == other.net.amount && self.tax.amount == other.tax.amount),
+            _ => op.matches(self.get_gross().amount.cmp(&other.get_gross().amount)),
+        }
     }
 
     #[staticmethod]


### PR DESCRIPTION
At the moment for MoneyWithVAT equality, we're comparing the gross amounts, which isn't what we want I think.

In the old implementation we were explicitly comparing net and tax, so probably an oversight during the setup.