### PR TITLE
chore(ci): Allow Actions to create a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci-permissions
     tags:
       - "*"
   pull_request:
@@ -53,7 +54,7 @@ jobs:
           path: dist
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs:
       - test
@@ -70,4 +71,5 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*"
+          tag: v0.1.1
           commit: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
     needs:
       - test
       - build
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci-permissions
     tags:
       - "*"
   pull_request:
@@ -54,7 +53,7 @@ jobs:
           path: dist
 
   release:
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs:
       - test
@@ -71,5 +70,4 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*"
-          tag: v0.1.1
           commit: ${{ github.sha }}


### PR DESCRIPTION
We have changed the defaults in https://alasco.atlassian.net/browse/PLAT-2226, and the defaults do not allow creating a release.