### PR TITLE
CST-1287: update comparison to allow comparing money to decimal like objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alasco-money"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "env_logger",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alasco-money"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "env_logger",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alasco-money"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alasco-money"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@
 
 ### Releasing a new version
  - Update the version in `Cargo.toml`
- - Tag the correponding `main` commit with `v${version}`
+ - Tag the corresponding `main` commit with `v${version}`
  - Wait for the release to be created by CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ classifiers = [
 dynamic = ["version"]
 
 [tool.uv]
-dev-dependencies = ["maturin", "pytest", "pydantic"]
+dev-dependencies = [
+    "maturin",
+    "pytest",
+    "pydantic",
+    "pip>=25.0.1",
+]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/pytests/test_money.py
+++ b/pytests/test_money.py
@@ -204,6 +204,9 @@ def test_equal_to_decimal_types():
     assert Money(Decimal("1000000")) == Decimal("1000000")
     assert Money(Decimal("1000000")) == 1000000
     assert Money("0") == 0
+    assert Money(0) == 0
+    assert Money(-1) != 0
+    assert Money(-1) == -1
 
 
 def test_lt():

--- a/pytests/test_money.py
+++ b/pytests/test_money.py
@@ -200,8 +200,10 @@ def test_equality_to_other_types():
     assert x != {}
 
 
-def test_not_equal_to_decimal_types():
-    assert Money(Decimal("1000000")) != Decimal("1000000")
+def test_equal_to_decimal_types():
+    assert Money(Decimal("1000000")) == Decimal("1000000")
+    assert Money(Decimal("1000000")) == 1000000
+    assert Money("0") == 0
 
 
 def test_lt():

--- a/src/money.rs
+++ b/src/money.rs
@@ -182,8 +182,17 @@ impl Money {
         !self.amount.is_zero()
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
-        op.matches(self.amount.cmp(&other.amount))
+    fn __richcmp__(&self, other: Bound<PyAny>, op: CompareOp) -> PyResult<bool> {
+        if let Ok(other_money) = other.extract::<Self>() {
+            Ok(op.matches(self.amount.cmp(&other_money.amount)))
+        } else if let Ok(other_decimal) = decimal_extract(other) {
+            Ok(op.matches(self.amount.cmp(&other_decimal)))
+        } else {
+            match op {
+                CompareOp::Ne => Ok(true),
+                _ => Ok(false),
+            }
+        }
     }
 
     pub fn for_json(&self) -> String {

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -8,11 +7,13 @@ resolution-markers = [
 
 [[package]]
 name = "alasco-money"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
     { name = "maturin" },
+    { name = "pip" },
     { name = "pydantic" },
     { name = "pytest" },
 ]
@@ -22,6 +23,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "maturin" },
+    { name = "pip", specifier = ">=25.0.1" },
     { name = "pydantic" },
     { name = "pytest" },
 ]
@@ -95,6 +97,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985 },
+]
+
+[[package]]
+name = "pip"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/53/b309b4a497b09655cb7e07088966881a57d082f48ac3cb54ea729fd2c6cf/pip-25.0.1.tar.gz", hash = "sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea", size = 1950850 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/bc/b7db44f5f39f9d0494071bddae6880eb645970366d0a200022a1a93d57f5/pip-25.0.1-py3-none-any.whl", hash = "sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f", size = 1841526 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Background
We had a problem where `Money` is not comparable to a decimal (see https://github.com/alasco-tech/alasco-app/pull/22474)
```
In [8]: _money.Money(0) == _money.Money(0)
Out[8]: True

In [9]: _money.Money(0) == 0
Out[9]: False

In [10]: _money.Money(0).amount == 0
Out[10]: True

In [11]: _decimal.Decimal(0) == 0
Out[11]: True
```

### Changes: 
* Allow comparing money to decimal values

### MISC:
* There was a test (and specific logic in [legacy money](https://github.com/alasco-tech/alasco-app/blob/master/backend/alasco/lib/money_legacy.py#L262)) to make sure we can not compare decimals to money, not sure what was the reason, if you know please come forward 
